### PR TITLE
Typescript bump, package security fixes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 aczekajski
+Copyright (c) 2018 x-kom
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "siema-react",
-    "version": "0.0.9",
+    "version": "0.1.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -387,6 +387,17 @@
             "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
             "dev": true
         },
+        "array.prototype.flat": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.1.tgz",
+            "integrity": "sha512-rVqIs330nLJvfC7JqYvEWwqVr5QjYF1ib02i3YJtR/fICO6527Tjpc/e4Mvmxh3GIePPreRXMdaGyC99YphWEw==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.10.0",
+                "function-bind": "^1.1.1"
+            }
+        },
         "arrify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
@@ -399,10 +410,13 @@
             "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
         },
         "asn1": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-            "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-            "dev": true
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+            "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+            "dev": true,
+            "requires": {
+                "safer-buffer": "~2.1.0"
+            }
         },
         "asn1.js": {
             "version": "4.9.2",
@@ -464,9 +478,9 @@
             "dev": true
         },
         "atob": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/atob/-/atob-2.0.3.tgz",
-            "integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10=",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+            "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
             "dev": true
         },
         "awesome-typescript-loader": {
@@ -492,9 +506,9 @@
             "dev": true
         },
         "aws4": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-            "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+            "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
             "dev": true
         },
         "babel-cli": {
@@ -570,9 +584,9 @@
             }
         },
         "babel-core": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
-            "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+            "version": "6.26.3",
+            "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+            "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
             "dev": true,
             "requires": {
                 "babel-code-frame": "^6.26.0",
@@ -585,15 +599,15 @@
                 "babel-traverse": "^6.26.0",
                 "babel-types": "^6.26.0",
                 "babylon": "^6.18.0",
-                "convert-source-map": "^1.5.0",
-                "debug": "^2.6.8",
+                "convert-source-map": "^1.5.1",
+                "debug": "^2.6.9",
                 "json5": "^0.5.1",
                 "lodash": "^4.17.4",
                 "minimatch": "^3.0.4",
                 "path-is-absolute": "^1.0.1",
-                "private": "^0.1.7",
+                "private": "^0.1.8",
                 "slash": "^1.0.0",
-                "source-map": "^0.5.6"
+                "source-map": "^0.5.7"
             }
         },
         "babel-generator": {
@@ -712,16 +726,6 @@
             "requires": {
                 "babel-runtime": "^6.22.0",
                 "babel-template": "^6.24.1"
-            }
-        },
-        "babel-jest": {
-            "version": "22.0.6",
-            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.0.6.tgz",
-            "integrity": "sha512-HkPxQ75YfYLjdaRTQn+a6fgHExPqsBLw9Gr6vDasylZBoiSEwhJUWE4Gh7mh4IC9zF/I+93mgTi5KsUjwOeeMA==",
-            "dev": true,
-            "requires": {
-                "babel-plugin-istanbul": "^4.1.5",
-                "babel-preset-jest": "^22.0.6"
             }
         },
         "babel-messages": {
@@ -883,9 +887,9 @@
             }
         },
         "babel-plugin-transform-es2015-modules-commonjs": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
-            "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
+            "version": "6.26.2",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+            "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
             "dev": true,
             "requires": {
                 "babel-plugin-transform-strict-mode": "^6.24.1",
@@ -1193,6 +1197,46 @@
                 "isobject": "^3.0.1",
                 "mixin-deep": "^1.2.0",
                 "pascalcase": "^0.1.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^1.0.0"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                }
             }
         },
         "base64-js": {
@@ -1208,9 +1252,9 @@
             "dev": true
         },
         "bcrypt-pbkdf": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-            "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+            "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
             "dev": true,
             "optional": true,
             "requires": {
@@ -1279,15 +1323,6 @@
             "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
             "dev": true
         },
-        "boom": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-            "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-            "dev": true,
-            "requires": {
-                "hoek": "4.x.x"
-            }
-        },
         "brace-expansion": {
             "version": "1.1.8",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
@@ -1299,14 +1334,13 @@
             }
         },
         "braces": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.0.tgz",
-            "integrity": "sha512-P4O8UQRdGiMLWSizsApmXVQDBS6KCt7dSexgLKBmH5Hr1CZq7vsnscFh8oR1sP1ab1Zj0uCHCEzZeV6SfUf3rA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+            "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
             "dev": true,
             "requires": {
                 "arr-flatten": "^1.1.0",
                 "array-unique": "^0.3.2",
-                "define-property": "^1.0.0",
                 "extend-shallow": "^2.0.1",
                 "fill-range": "^4.0.0",
                 "isobject": "^3.0.1",
@@ -1315,6 +1349,17 @@
                 "snapdragon-node": "^2.0.1",
                 "split-string": "^3.0.2",
                 "to-regex": "^3.0.1"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
             }
         },
         "brorand": {
@@ -1426,6 +1471,12 @@
                 "base64-js": "^1.0.2",
                 "ieee754": "^1.1.4"
             }
+        },
+        "buffer-from": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+            "dev": true
         },
         "buffer-indexof": {
             "version": "1.1.1",
@@ -1564,9 +1615,9 @@
             },
             "dependencies": {
                 "domhandler": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
-                    "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+                    "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
                     "dev": true,
                     "requires": {
                         "domelementtype": "1"
@@ -1622,15 +1673,14 @@
             }
         },
         "class-utils": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.5.tgz",
-            "integrity": "sha1-F+eTEDdQ+WJ7IXbqNM/RtWWQPIA=",
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+            "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
             "dev": true,
             "requires": {
                 "arr-union": "^3.1.0",
                 "define-property": "^0.2.5",
                 "isobject": "^3.0.0",
-                "lazy-cache": "^2.0.2",
                 "static-extend": "^0.1.1"
             },
             "dependencies": {
@@ -1642,63 +1692,6 @@
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
-                },
-                "is-accessor-descriptor": {
-                    "version": "0.1.6",
-                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-                    "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "dev": true,
-                            "requires": {
-                                "is-buffer": "^1.1.5"
-                            }
-                        }
-                    }
-                },
-                "is-data-descriptor": {
-                    "version": "0.1.4",
-                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-                    "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "dev": true,
-                            "requires": {
-                                "is-buffer": "^1.1.5"
-                            }
-                        }
-                    }
-                },
-                "is-descriptor": {
-                    "version": "0.1.6",
-                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-                    "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-                    "dev": true,
-                    "requires": {
-                        "is-accessor-descriptor": "^0.1.6",
-                        "is-data-descriptor": "^0.1.4",
-                        "kind-of": "^5.0.0"
-                    }
-                },
-                "kind-of": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-                    "dev": true
                 }
             }
         },
@@ -1774,9 +1767,9 @@
             "dev": true
         },
         "combined-stream": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-            "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+            "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
             "dev": true,
             "requires": {
                 "delayed-stream": "~1.0.0"
@@ -1964,26 +1957,6 @@
                 "which": "^1.2.9"
             }
         },
-        "cryptiles": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-            "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-            "dev": true,
-            "requires": {
-                "boom": "5.x.x"
-            },
-            "dependencies": {
-                "boom": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-                    "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-                    "dev": true,
-                    "requires": {
-                        "hoek": "4.x.x"
-                    }
-                }
-            }
-        },
         "crypto-browserify": {
             "version": "3.12.0",
             "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
@@ -2139,12 +2112,44 @@
             }
         },
         "define-property": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-            "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+            "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
             "dev": true,
             "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "^1.0.2",
+                "isobject": "^3.0.1"
+            },
+            "dependencies": {
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                }
             }
         },
         "del": {
@@ -2375,13 +2380,14 @@
             "dev": true
         },
         "ecc-jsbn": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-            "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
             "dev": true,
             "optional": true,
             "requires": {
-                "jsbn": "~0.1.0"
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
             }
         },
         "ee-first": {
@@ -2444,53 +2450,96 @@
             "dev": true
         },
         "enzyme": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.3.0.tgz",
-            "integrity": "sha512-l8csyPyLmtxskTz6pX9W8eDOyH1ckEtDttXk/vlFWCjv00SkjTjtoUrogqp4yEvMyneU9dUJoOLnqFoiHb8IHA==",
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.4.4.tgz",
+            "integrity": "sha512-/xkHs9vLDmmZbyvhu0zgBHqK+aAZHyTTXvclLjATqo4SlnpReZ7JqEyrjADAhy2Kha0gKmKq4759E/+VjIExMg==",
             "dev": true,
             "requires": {
+                "array.prototype.flat": "^1.2.1",
                 "cheerio": "^1.0.0-rc.2",
-                "function.prototype.name": "^1.0.3",
-                "has": "^1.0.1",
+                "function.prototype.name": "^1.1.0",
+                "has": "^1.0.3",
                 "is-boolean-object": "^1.0.0",
-                "is-callable": "^1.1.3",
+                "is-callable": "^1.1.4",
                 "is-number-object": "^1.0.3",
                 "is-string": "^1.0.4",
                 "is-subset": "^0.1.1",
                 "lodash": "^4.17.4",
-                "object-inspect": "^1.5.0",
+                "object-inspect": "^1.6.0",
                 "object-is": "^1.0.1",
                 "object.assign": "^4.1.0",
                 "object.entries": "^1.0.4",
                 "object.values": "^1.0.4",
                 "raf": "^3.4.0",
                 "rst-selector-parser": "^2.2.3"
+            },
+            "dependencies": {
+                "has": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+                    "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+                    "dev": true,
+                    "requires": {
+                        "function-bind": "^1.1.1"
+                    }
+                },
+                "is-callable": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+                    "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+                    "dev": true
+                }
             }
         },
         "enzyme-adapter-react-16": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.1.1.tgz",
-            "integrity": "sha512-kC8pAtU2Jk3OJ0EG8Y2813dg9Ol0TXi7UNxHzHiWs30Jo/hj7alc//G1YpKUsPP1oKl9X+Lkx+WlGJpPYA+nvw==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.2.0.tgz",
+            "integrity": "sha512-UgBra+xZFVFbU5Tw7Inw0bPrNJhM2ru4vCoO7preX6sOicXuDbOH927QJx4pk6m6vatd8jnPXTF6/GCjzytJTg==",
             "dev": true,
             "requires": {
-                "enzyme-adapter-utils": "^1.3.0",
-                "lodash": "^4.17.4",
-                "object.assign": "^4.0.4",
+                "enzyme-adapter-utils": "^1.5.0",
+                "function.prototype.name": "^1.1.0",
+                "object.assign": "^4.1.0",
                 "object.values": "^1.0.4",
-                "prop-types": "^15.6.0",
+                "prop-types": "^15.6.2",
+                "react-is": "^16.4.2",
                 "react-reconciler": "^0.7.0",
                 "react-test-renderer": "^16.0.0-0"
+            },
+            "dependencies": {
+                "prop-types": {
+                    "version": "15.6.2",
+                    "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+                    "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+                    "dev": true,
+                    "requires": {
+                        "loose-envify": "^1.3.1",
+                        "object-assign": "^4.1.1"
+                    }
+                }
             }
         },
         "enzyme-adapter-utils": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.3.0.tgz",
-            "integrity": "sha512-vVXSt6uDv230DIv+ebCG66T1Pm36Kv+m74L1TrF4kaE7e1V7Q/LcxO0QRkajk5cA6R3uu9wJf5h13wOTezTbjA==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.5.0.tgz",
+            "integrity": "sha512-cLUaPYU8GEzAHi/1hiO+ylz4QiQWI8eb9SysAk8Tbul2O918dRf4cfD4s2BjijtwSvhapkOsPW9XRix1EXlJ1Q==",
             "dev": true,
             "requires": {
-                "lodash": "^4.17.4",
-                "object.assign": "^4.0.4",
-                "prop-types": "^15.6.0"
+                "function.prototype.name": "^1.1.0",
+                "object.assign": "^4.1.0",
+                "prop-types": "^15.6.2"
+            },
+            "dependencies": {
+                "prop-types": {
+                    "version": "15.6.2",
+                    "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+                    "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+                    "dev": true,
+                    "requires": {
+                        "loose-envify": "^1.3.1",
+                        "object-assign": "^4.1.1"
+                    }
+                }
             }
         },
         "errno": {
@@ -2758,6 +2807,12 @@
                 "strip-eof": "^1.0.0"
             }
         },
+        "exit": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+            "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+            "dev": true
+        },
         "expand-brackets": {
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
@@ -2782,62 +2837,14 @@
                         "is-descriptor": "^0.1.0"
                     }
                 },
-                "is-accessor-descriptor": {
-                    "version": "0.1.6",
-                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-                    "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "dev": true,
-                            "requires": {
-                                "is-buffer": "^1.1.5"
-                            }
-                        }
+                        "is-extendable": "^0.1.0"
                     }
-                },
-                "is-data-descriptor": {
-                    "version": "0.1.4",
-                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-                    "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "dev": true,
-                            "requires": {
-                                "is-buffer": "^1.1.5"
-                            }
-                        }
-                    }
-                },
-                "is-descriptor": {
-                    "version": "0.1.6",
-                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-                    "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-                    "dev": true,
-                    "requires": {
-                        "is-accessor-descriptor": "^0.1.6",
-                        "is-data-descriptor": "^0.1.4",
-                        "kind-of": "^5.0.0"
-                    }
-                },
-                "kind-of": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-                    "dev": true
                 }
             }
         },
@@ -2851,16 +2858,43 @@
             },
             "dependencies": {
                 "fill-range": {
-                    "version": "2.2.3",
-                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-                    "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+                    "version": "2.2.4",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+                    "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
                     "dev": true,
                     "requires": {
                         "is-number": "^2.1.0",
                         "isobject": "^2.0.0",
-                        "randomatic": "^1.1.3",
+                        "randomatic": "^3.0.0",
                         "repeat-element": "^1.1.2",
                         "repeat-string": "^1.5.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "6.0.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                            "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                            "dev": true
+                        },
+                        "randomatic": {
+                            "version": "3.1.0",
+                            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.0.tgz",
+                            "integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
+                            "dev": true,
+                            "requires": {
+                                "is-number": "^4.0.0",
+                                "kind-of": "^6.0.0",
+                                "math-random": "^1.0.1"
+                            },
+                            "dependencies": {
+                                "is-number": {
+                                    "version": "4.0.0",
+                                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+                                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+                                    "dev": true
+                                }
+                            }
+                        }
                     }
                 },
                 "is-number": {
@@ -2953,24 +2987,36 @@
             }
         },
         "extend": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-            "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
             "dev": true
         },
         "extend-shallow": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+            "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
             "dev": true,
             "requires": {
-                "is-extendable": "^0.1.0"
+                "assign-symbols": "^1.0.0",
+                "is-extendable": "^1.0.1"
+            },
+            "dependencies": {
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "dev": true,
+                    "requires": {
+                        "is-plain-object": "^2.0.4"
+                    }
+                }
             }
         },
         "extglob": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.3.tgz",
-            "integrity": "sha512-AyptZexgu7qppEPq59DtN/XJGZDrLcVxSHai+4hdgMMS9EpF4GBvygcWWApno8lL9qSjVpYt7Raao28qzJX1ww==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+            "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
             "dev": true,
             "requires": {
                 "array-unique": "^0.3.2",
@@ -2981,6 +3027,55 @@
                 "regex-not": "^1.0.0",
                 "snapdragon": "^0.8.1",
                 "to-regex": "^3.0.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^1.0.0"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                }
             }
         },
         "extsprintf": {
@@ -3065,6 +3160,17 @@
                 "is-number": "^3.0.0",
                 "repeat-string": "^1.6.1",
                 "to-regex-range": "^2.1.0"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
             }
         },
         "finalhandler": {
@@ -3125,13 +3231,13 @@
             "dev": true
         },
         "form-data": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-            "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+            "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
             "dev": true,
             "requires": {
                 "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.5",
+                "combined-stream": "1.0.6",
                 "mime-types": "^2.1.12"
             }
         },
@@ -3917,12 +4023,12 @@
             "dev": true
         },
         "har-validator": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-            "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
+            "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
             "dev": true,
             "requires": {
-                "ajv": "^5.1.0",
+                "ajv": "^5.3.0",
                 "har-schema": "^2.0.0"
             }
         },
@@ -4007,18 +4113,6 @@
                 "minimalistic-assert": "^1.0.0"
             }
         },
-        "hawk": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-            "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-            "dev": true,
-            "requires": {
-                "boom": "4.x.x",
-                "cryptiles": "3.x.x",
-                "hoek": "4.x.x",
-                "sntp": "2.x.x"
-            }
-        },
         "he": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
@@ -4035,12 +4129,6 @@
                 "minimalistic-assert": "^1.0.0",
                 "minimalistic-crypto-utils": "^1.0.1"
             }
-        },
-        "hoek": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-            "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
-            "dev": true
         },
         "hoist-non-react-statics": {
             "version": "1.2.0",
@@ -4479,12 +4567,23 @@
             "dev": true
         },
         "is-accessor-descriptor": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-            "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+            "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
             "dev": true,
             "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "^3.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
             }
         },
         "is-arrayish": {
@@ -4539,12 +4638,23 @@
             }
         },
         "is-data-descriptor": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-            "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+            "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
             "dev": true,
             "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "^3.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
             }
         },
         "is-date-object": {
@@ -4554,14 +4664,22 @@
             "dev": true
         },
         "is-descriptor": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-            "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+            "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
             "dev": true,
             "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
+                }
             }
         },
         "is-dotfile": {
@@ -4646,15 +4764,6 @@
             "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.3.tgz",
             "integrity": "sha1-8mWrian0RQNO9q/xWo8AsA9VF5k=",
             "dev": true
-        },
-        "is-odd": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-1.0.0.tgz",
-            "integrity": "sha1-O4qTLrAos3dcObsJ6RdnrM22kIg=",
-            "dev": true,
-            "requires": {
-                "is-number": "^3.0.0"
-            }
         },
         "is-path-cwd": {
             "version": "1.0.0",
@@ -4743,6 +4852,12 @@
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
             "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+            "dev": true
+        },
+        "is-windows": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
             "dev": true
         },
         "is-wsl": {
@@ -4925,6 +5040,32 @@
                     "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
                     "dev": true
                 },
+                "babel-jest": {
+                    "version": "22.4.4",
+                    "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.4.4.tgz",
+                    "integrity": "sha512-A9NB6/lZhYyypR9ATryOSDcqBaqNdzq4U+CN+/wcMsLcmKkPxQEoTKLajGfd3IkxNyVBT8NewUK2nWyGbSzHEQ==",
+                    "dev": true,
+                    "requires": {
+                        "babel-plugin-istanbul": "^4.1.5",
+                        "babel-preset-jest": "^22.4.4"
+                    }
+                },
+                "babel-plugin-jest-hoist": {
+                    "version": "22.4.4",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.4.tgz",
+                    "integrity": "sha512-DUvGfYaAIlkdnygVIEl0O4Av69NtuQWcrjMOv6DODPuhuGLDnbsARz3AwiiI/EkIMMlxQDUcrZ9yoyJvTNjcVQ==",
+                    "dev": true
+                },
+                "babel-preset-jest": {
+                    "version": "22.4.4",
+                    "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.4.tgz",
+                    "integrity": "sha512-+dxMtOFwnSYWfum0NaEc0O03oSdwBsjx4tMSChRDPGwu/4wSY6Q6ANW3wkjKpJzzguaovRs/DODcT4hbSN8yiA==",
+                    "dev": true,
+                    "requires": {
+                        "babel-plugin-jest-hoist": "^22.4.4",
+                        "babel-plugin-syntax-object-rest-spread": "^6.13.0"
+                    }
+                },
                 "braces": {
                     "version": "1.8.5",
                     "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
@@ -4945,6 +5086,47 @@
                         "is-posix-bracket": "^0.1.0"
                     }
                 },
+                "expect": {
+                    "version": "22.4.3",
+                    "resolved": "https://registry.npmjs.org/expect/-/expect-22.4.3.tgz",
+                    "integrity": "sha512-XcNXEPehqn8b/jm8FYotdX0YrXn36qp4HWlrVT4ktwQas1l1LPxiVWncYnnL2eyMtKAmVIaG0XAp0QlrqJaxaA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.0",
+                        "jest-diff": "^22.4.3",
+                        "jest-get-type": "^22.4.3",
+                        "jest-matcher-utils": "^22.4.3",
+                        "jest-message-util": "^22.4.3",
+                        "jest-regex-util": "^22.4.3"
+                    },
+                    "dependencies": {
+                        "jest-get-type": {
+                            "version": "22.4.3",
+                            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+                            "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
+                            "dev": true
+                        },
+                        "jest-message-util": {
+                            "version": "22.4.3",
+                            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.3.tgz",
+                            "integrity": "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
+                            "dev": true,
+                            "requires": {
+                                "@babel/code-frame": "^7.0.0-beta.35",
+                                "chalk": "^2.0.1",
+                                "micromatch": "^2.3.11",
+                                "slash": "^1.0.0",
+                                "stack-utils": "^1.0.1"
+                            }
+                        },
+                        "jest-regex-util": {
+                            "version": "22.4.3",
+                            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.4.3.tgz",
+                            "integrity": "sha512-LFg1gWr3QinIjb8j833bq7jtQopiwdAs67OGfkPrvy7uNUbVMfTXXcOKXJaeY5GgjobELkKvKENqq1xrUectWg==",
+                            "dev": true
+                        }
+                    }
+                },
                 "extglob": {
                     "version": "0.3.2",
                     "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
@@ -4954,36 +5136,49 @@
                         "is-extglob": "^1.0.0"
                     }
                 },
+                "import-local": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
+                    "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+                    "dev": true,
+                    "requires": {
+                        "pkg-dir": "^2.0.0",
+                        "resolve-cwd": "^2.0.0"
+                    }
+                },
                 "jest-cli": {
-                    "version": "22.0.6",
-                    "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.0.6.tgz",
-                    "integrity": "sha512-0hqadrUDDj4FDmrODXvLXCFwHGMegH+2fZ6x3Y0SyKw7ODJ91+2WeVCQwQRXaj6v9hmygjsbfdGo3tYIeOZVhw==",
+                    "version": "22.4.4",
+                    "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.4.4.tgz",
+                    "integrity": "sha512-I9dsgkeyjVEEZj9wrGrqlH+8OlNob9Iptyl+6L5+ToOLJmHm4JwOPatin1b2Bzp5R5YRQJ+oiedx7o1H7wJzhA==",
                     "dev": true,
                     "requires": {
                         "ansi-escapes": "^3.0.0",
                         "chalk": "^2.0.1",
+                        "exit": "^0.1.2",
                         "glob": "^7.1.2",
                         "graceful-fs": "^4.1.11",
+                        "import-local": "^1.0.0",
                         "is-ci": "^1.0.10",
                         "istanbul-api": "^1.1.14",
                         "istanbul-lib-coverage": "^1.1.1",
                         "istanbul-lib-instrument": "^1.8.0",
                         "istanbul-lib-source-maps": "^1.2.1",
-                        "jest-changed-files": "^22.0.6",
-                        "jest-config": "^22.0.6",
-                        "jest-environment-jsdom": "^22.0.6",
-                        "jest-get-type": "^22.0.6",
-                        "jest-haste-map": "^22.0.6",
-                        "jest-message-util": "^22.0.6",
-                        "jest-regex-util": "^22.0.6",
-                        "jest-resolve-dependencies": "^22.0.6",
-                        "jest-runner": "^22.0.6",
-                        "jest-runtime": "^22.0.6",
-                        "jest-snapshot": "^22.0.6",
-                        "jest-util": "^22.0.6",
-                        "jest-worker": "^22.0.6",
+                        "jest-changed-files": "^22.2.0",
+                        "jest-config": "^22.4.4",
+                        "jest-environment-jsdom": "^22.4.1",
+                        "jest-get-type": "^22.1.0",
+                        "jest-haste-map": "^22.4.2",
+                        "jest-message-util": "^22.4.0",
+                        "jest-regex-util": "^22.1.0",
+                        "jest-resolve-dependencies": "^22.1.0",
+                        "jest-runner": "^22.4.4",
+                        "jest-runtime": "^22.4.4",
+                        "jest-snapshot": "^22.4.0",
+                        "jest-util": "^22.4.1",
+                        "jest-validate": "^22.4.4",
+                        "jest-worker": "^22.2.2",
                         "micromatch": "^2.3.11",
-                        "node-notifier": "^5.1.2",
+                        "node-notifier": "^5.2.1",
                         "realpath-native": "^1.0.0",
                         "rimraf": "^2.5.4",
                         "slash": "^1.0.0",
@@ -4991,6 +5186,454 @@
                         "strip-ansi": "^4.0.0",
                         "which": "^1.2.12",
                         "yargs": "^10.0.3"
+                    },
+                    "dependencies": {
+                        "jest-changed-files": {
+                            "version": "22.4.3",
+                            "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-22.4.3.tgz",
+                            "integrity": "sha512-83Dh0w1aSkUNFhy5d2dvqWxi/y6weDwVVLU6vmK0cV9VpRxPzhTeGimbsbRDSnEoszhF937M4sDLLeS7Cu/Tmw==",
+                            "dev": true,
+                            "requires": {
+                                "throat": "^4.0.0"
+                            }
+                        },
+                        "jest-config": {
+                            "version": "22.4.4",
+                            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.4.4.tgz",
+                            "integrity": "sha512-9CKfo1GC4zrXSoMLcNeDvQBfgtqGTB1uP8iDIZ97oB26RCUb886KkKWhVcpyxVDOUxbhN+uzcBCeFe7w+Iem4A==",
+                            "dev": true,
+                            "requires": {
+                                "chalk": "^2.0.1",
+                                "glob": "^7.1.1",
+                                "jest-environment-jsdom": "^22.4.1",
+                                "jest-environment-node": "^22.4.1",
+                                "jest-get-type": "^22.1.0",
+                                "jest-jasmine2": "^22.4.4",
+                                "jest-regex-util": "^22.1.0",
+                                "jest-resolve": "^22.4.2",
+                                "jest-util": "^22.4.1",
+                                "jest-validate": "^22.4.4",
+                                "pretty-format": "^22.4.0"
+                            }
+                        },
+                        "jest-environment-jsdom": {
+                            "version": "22.4.3",
+                            "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.3.tgz",
+                            "integrity": "sha512-FviwfR+VyT3Datf13+ULjIMO5CSeajlayhhYQwpzgunswoaLIPutdbrnfUHEMyJCwvqQFaVtTmn9+Y8WCt6n1w==",
+                            "dev": true,
+                            "requires": {
+                                "jest-mock": "^22.4.3",
+                                "jest-util": "^22.4.3",
+                                "jsdom": "^11.5.1"
+                            }
+                        },
+                        "jest-get-type": {
+                            "version": "22.4.3",
+                            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+                            "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
+                            "dev": true
+                        },
+                        "jest-haste-map": {
+                            "version": "22.4.3",
+                            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.4.3.tgz",
+                            "integrity": "sha512-4Q9fjzuPVwnaqGKDpIsCSoTSnG3cteyk2oNVjBX12HHOaF1oxql+uUiqZb5Ndu7g/vTZfdNwwy4WwYogLh29DQ==",
+                            "dev": true,
+                            "requires": {
+                                "fb-watchman": "^2.0.0",
+                                "graceful-fs": "^4.1.11",
+                                "jest-docblock": "^22.4.3",
+                                "jest-serializer": "^22.4.3",
+                                "jest-worker": "^22.4.3",
+                                "micromatch": "^2.3.11",
+                                "sane": "^2.0.0"
+                            }
+                        },
+                        "jest-message-util": {
+                            "version": "22.4.3",
+                            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.3.tgz",
+                            "integrity": "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
+                            "dev": true,
+                            "requires": {
+                                "@babel/code-frame": "^7.0.0-beta.35",
+                                "chalk": "^2.0.1",
+                                "micromatch": "^2.3.11",
+                                "slash": "^1.0.0",
+                                "stack-utils": "^1.0.1"
+                            }
+                        },
+                        "jest-regex-util": {
+                            "version": "22.4.3",
+                            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.4.3.tgz",
+                            "integrity": "sha512-LFg1gWr3QinIjb8j833bq7jtQopiwdAs67OGfkPrvy7uNUbVMfTXXcOKXJaeY5GgjobELkKvKENqq1xrUectWg==",
+                            "dev": true
+                        },
+                        "jest-resolve-dependencies": {
+                            "version": "22.4.3",
+                            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-22.4.3.tgz",
+                            "integrity": "sha512-06czCMVToSN8F2U4EvgSB1Bv/56gc7MpCftZ9z9fBgUQM7dzHGCMBsyfVA6dZTx8v0FDcnALf7hupeQxaBCvpA==",
+                            "dev": true,
+                            "requires": {
+                                "jest-regex-util": "^22.4.3"
+                            }
+                        },
+                        "jest-runner": {
+                            "version": "22.4.4",
+                            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.4.4.tgz",
+                            "integrity": "sha512-5S/OpB51igQW9xnkM5Tgd/7ZjiAuIoiJAVtvVTBcEBiXBIFzWM3BAMPBM19FX68gRV0KWyFuGKj0EY3M3aceeQ==",
+                            "dev": true,
+                            "requires": {
+                                "exit": "^0.1.2",
+                                "jest-config": "^22.4.4",
+                                "jest-docblock": "^22.4.0",
+                                "jest-haste-map": "^22.4.2",
+                                "jest-jasmine2": "^22.4.4",
+                                "jest-leak-detector": "^22.4.0",
+                                "jest-message-util": "^22.4.0",
+                                "jest-runtime": "^22.4.4",
+                                "jest-util": "^22.4.1",
+                                "jest-worker": "^22.2.2",
+                                "throat": "^4.0.0"
+                            }
+                        },
+                        "jest-runtime": {
+                            "version": "22.4.4",
+                            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.4.tgz",
+                            "integrity": "sha512-WRTj9m///npte1YjuphCYX7GRY/c2YvJImU9t7qOwFcqHr4YMzmX6evP/3Sehz5DKW2Vi8ONYPCFWe36JVXxfw==",
+                            "dev": true,
+                            "requires": {
+                                "babel-core": "^6.0.0",
+                                "babel-jest": "^22.4.4",
+                                "babel-plugin-istanbul": "^4.1.5",
+                                "chalk": "^2.0.1",
+                                "convert-source-map": "^1.4.0",
+                                "exit": "^0.1.2",
+                                "graceful-fs": "^4.1.11",
+                                "jest-config": "^22.4.4",
+                                "jest-haste-map": "^22.4.2",
+                                "jest-regex-util": "^22.1.0",
+                                "jest-resolve": "^22.4.2",
+                                "jest-util": "^22.4.1",
+                                "jest-validate": "^22.4.4",
+                                "json-stable-stringify": "^1.0.1",
+                                "micromatch": "^2.3.11",
+                                "realpath-native": "^1.0.0",
+                                "slash": "^1.0.0",
+                                "strip-bom": "3.0.0",
+                                "write-file-atomic": "^2.1.0",
+                                "yargs": "^10.0.3"
+                            }
+                        },
+                        "jest-snapshot": {
+                            "version": "22.4.3",
+                            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.4.3.tgz",
+                            "integrity": "sha512-JXA0gVs5YL0HtLDCGa9YxcmmV2LZbwJ+0MfyXBBc5qpgkEYITQFJP7XNhcHFbUvRiniRpRbGVfJrOoYhhGE0RQ==",
+                            "dev": true,
+                            "requires": {
+                                "chalk": "^2.0.1",
+                                "jest-diff": "^22.4.3",
+                                "jest-matcher-utils": "^22.4.3",
+                                "mkdirp": "^0.5.1",
+                                "natural-compare": "^1.4.0",
+                                "pretty-format": "^22.4.3"
+                            }
+                        },
+                        "jest-util": {
+                            "version": "22.4.3",
+                            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.4.3.tgz",
+                            "integrity": "sha512-rfDfG8wyC5pDPNdcnAlZgwKnzHvZDu8Td2NJI/jAGKEGxJPYiE4F0ss/gSAkG4778Y23Hvbz+0GMrDJTeo7RjQ==",
+                            "dev": true,
+                            "requires": {
+                                "callsites": "^2.0.0",
+                                "chalk": "^2.0.1",
+                                "graceful-fs": "^4.1.11",
+                                "is-ci": "^1.0.10",
+                                "jest-message-util": "^22.4.3",
+                                "mkdirp": "^0.5.1",
+                                "source-map": "^0.6.0"
+                            }
+                        },
+                        "jest-worker": {
+                            "version": "22.4.3",
+                            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.4.3.tgz",
+                            "integrity": "sha512-B1ucW4fI8qVAuZmicFxI1R3kr2fNeYJyvIQ1rKcuLYnenFV5K5aMbxFj6J0i00Ju83S8jP2d7Dz14+AvbIHRYQ==",
+                            "dev": true,
+                            "requires": {
+                                "merge-stream": "^1.0.1"
+                            }
+                        },
+                        "node-notifier": {
+                            "version": "5.2.1",
+                            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
+                            "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
+                            "dev": true,
+                            "requires": {
+                                "growly": "^1.3.0",
+                                "semver": "^5.4.1",
+                                "shellwords": "^0.1.1",
+                                "which": "^1.3.0"
+                            }
+                        }
+                    }
+                },
+                "jest-diff": {
+                    "version": "22.4.3",
+                    "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz",
+                    "integrity": "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.0.1",
+                        "diff": "^3.2.0",
+                        "jest-get-type": "^22.4.3",
+                        "pretty-format": "^22.4.3"
+                    },
+                    "dependencies": {
+                        "jest-get-type": {
+                            "version": "22.4.3",
+                            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+                            "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
+                            "dev": true
+                        }
+                    }
+                },
+                "jest-docblock": {
+                    "version": "22.4.3",
+                    "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.4.3.tgz",
+                    "integrity": "sha512-uPKBEAw7YrEMcXueMKZXn/rbMxBiSv48fSqy3uEnmgOlQhSX+lthBqHb1fKWNVmFqAp9E/RsSdBfiV31LbzaOg==",
+                    "dev": true,
+                    "requires": {
+                        "detect-newline": "^2.1.0"
+                    }
+                },
+                "jest-environment-node": {
+                    "version": "22.4.3",
+                    "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.4.3.tgz",
+                    "integrity": "sha512-reZl8XF6t/lMEuPWwo9OLfttyC26A5AMgDyEQ6DBgZuyfyeNUzYT8BFo6uxCCP/Av/b7eb9fTi3sIHFPBzmlRA==",
+                    "dev": true,
+                    "requires": {
+                        "jest-mock": "^22.4.3",
+                        "jest-util": "^22.4.3"
+                    },
+                    "dependencies": {
+                        "jest-message-util": {
+                            "version": "22.4.3",
+                            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.3.tgz",
+                            "integrity": "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
+                            "dev": true,
+                            "requires": {
+                                "@babel/code-frame": "^7.0.0-beta.35",
+                                "chalk": "^2.0.1",
+                                "micromatch": "^2.3.11",
+                                "slash": "^1.0.0",
+                                "stack-utils": "^1.0.1"
+                            }
+                        },
+                        "jest-util": {
+                            "version": "22.4.3",
+                            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.4.3.tgz",
+                            "integrity": "sha512-rfDfG8wyC5pDPNdcnAlZgwKnzHvZDu8Td2NJI/jAGKEGxJPYiE4F0ss/gSAkG4778Y23Hvbz+0GMrDJTeo7RjQ==",
+                            "dev": true,
+                            "requires": {
+                                "callsites": "^2.0.0",
+                                "chalk": "^2.0.1",
+                                "graceful-fs": "^4.1.11",
+                                "is-ci": "^1.0.10",
+                                "jest-message-util": "^22.4.3",
+                                "mkdirp": "^0.5.1",
+                                "source-map": "^0.6.0"
+                            }
+                        }
+                    }
+                },
+                "jest-jasmine2": {
+                    "version": "22.4.4",
+                    "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.4.4.tgz",
+                    "integrity": "sha512-nK3vdUl50MuH7vj/8at7EQVjPGWCi3d5+6aCi7Gxy/XMWdOdbH1qtO/LjKbqD8+8dUAEH+BVVh7HkjpCWC1CSw==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.0.1",
+                        "co": "^4.6.0",
+                        "expect": "^22.4.0",
+                        "graceful-fs": "^4.1.11",
+                        "is-generator-fn": "^1.0.0",
+                        "jest-diff": "^22.4.0",
+                        "jest-matcher-utils": "^22.4.0",
+                        "jest-message-util": "^22.4.0",
+                        "jest-snapshot": "^22.4.0",
+                        "jest-util": "^22.4.1",
+                        "source-map-support": "^0.5.0"
+                    },
+                    "dependencies": {
+                        "jest-message-util": {
+                            "version": "22.4.3",
+                            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.3.tgz",
+                            "integrity": "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
+                            "dev": true,
+                            "requires": {
+                                "@babel/code-frame": "^7.0.0-beta.35",
+                                "chalk": "^2.0.1",
+                                "micromatch": "^2.3.11",
+                                "slash": "^1.0.0",
+                                "stack-utils": "^1.0.1"
+                            }
+                        },
+                        "jest-snapshot": {
+                            "version": "22.4.3",
+                            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.4.3.tgz",
+                            "integrity": "sha512-JXA0gVs5YL0HtLDCGa9YxcmmV2LZbwJ+0MfyXBBc5qpgkEYITQFJP7XNhcHFbUvRiniRpRbGVfJrOoYhhGE0RQ==",
+                            "dev": true,
+                            "requires": {
+                                "chalk": "^2.0.1",
+                                "jest-diff": "^22.4.3",
+                                "jest-matcher-utils": "^22.4.3",
+                                "mkdirp": "^0.5.1",
+                                "natural-compare": "^1.4.0",
+                                "pretty-format": "^22.4.3"
+                            }
+                        },
+                        "jest-util": {
+                            "version": "22.4.3",
+                            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.4.3.tgz",
+                            "integrity": "sha512-rfDfG8wyC5pDPNdcnAlZgwKnzHvZDu8Td2NJI/jAGKEGxJPYiE4F0ss/gSAkG4778Y23Hvbz+0GMrDJTeo7RjQ==",
+                            "dev": true,
+                            "requires": {
+                                "callsites": "^2.0.0",
+                                "chalk": "^2.0.1",
+                                "graceful-fs": "^4.1.11",
+                                "is-ci": "^1.0.10",
+                                "jest-message-util": "^22.4.3",
+                                "mkdirp": "^0.5.1",
+                                "source-map": "^0.6.0"
+                            }
+                        }
+                    }
+                },
+                "jest-leak-detector": {
+                    "version": "22.4.3",
+                    "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.4.3.tgz",
+                    "integrity": "sha512-NZpR/Ls7+ndO57LuXROdgCGz2RmUdC541tTImL9bdUtU3WadgFGm0yV+Ok4Fuia/1rLAn5KaJ+i76L6e3zGJYQ==",
+                    "dev": true,
+                    "requires": {
+                        "pretty-format": "^22.4.3"
+                    }
+                },
+                "jest-matcher-utils": {
+                    "version": "22.4.3",
+                    "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz",
+                    "integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.0.1",
+                        "jest-get-type": "^22.4.3",
+                        "pretty-format": "^22.4.3"
+                    },
+                    "dependencies": {
+                        "jest-get-type": {
+                            "version": "22.4.3",
+                            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+                            "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
+                            "dev": true
+                        }
+                    }
+                },
+                "jest-mock": {
+                    "version": "22.4.3",
+                    "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-22.4.3.tgz",
+                    "integrity": "sha512-+4R6mH5M1G4NK16CKg9N1DtCaFmuxhcIqF4lQK/Q1CIotqMs/XBemfpDPeVZBFow6iyUNu6EBT9ugdNOTT5o5Q==",
+                    "dev": true
+                },
+                "jest-resolve": {
+                    "version": "22.4.3",
+                    "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.4.3.tgz",
+                    "integrity": "sha512-u3BkD/MQBmwrOJDzDIaxpyqTxYH+XqAXzVJP51gt29H8jpj3QgKof5GGO2uPGKGeA1yTMlpbMs1gIQ6U4vcRhw==",
+                    "dev": true,
+                    "requires": {
+                        "browser-resolve": "^1.11.2",
+                        "chalk": "^2.0.1"
+                    }
+                },
+                "jest-validate": {
+                    "version": "22.4.4",
+                    "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.4.tgz",
+                    "integrity": "sha512-dmlf4CIZRGvkaVg3fa0uetepcua44DHtktHm6rcoNVtYlpwe6fEJRkMFsaUVcFHLzbuBJ2cPw9Gl9TKfnzMVwg==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.0.1",
+                        "jest-config": "^22.4.4",
+                        "jest-get-type": "^22.1.0",
+                        "leven": "^2.1.0",
+                        "pretty-format": "^22.4.0"
+                    },
+                    "dependencies": {
+                        "jest-config": {
+                            "version": "22.4.4",
+                            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.4.4.tgz",
+                            "integrity": "sha512-9CKfo1GC4zrXSoMLcNeDvQBfgtqGTB1uP8iDIZ97oB26RCUb886KkKWhVcpyxVDOUxbhN+uzcBCeFe7w+Iem4A==",
+                            "dev": true,
+                            "requires": {
+                                "chalk": "^2.0.1",
+                                "glob": "^7.1.1",
+                                "jest-environment-jsdom": "^22.4.1",
+                                "jest-environment-node": "^22.4.1",
+                                "jest-get-type": "^22.1.0",
+                                "jest-jasmine2": "^22.4.4",
+                                "jest-regex-util": "^22.1.0",
+                                "jest-resolve": "^22.4.2",
+                                "jest-util": "^22.4.1",
+                                "jest-validate": "^22.4.4",
+                                "pretty-format": "^22.4.0"
+                            }
+                        },
+                        "jest-environment-jsdom": {
+                            "version": "22.4.3",
+                            "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.3.tgz",
+                            "integrity": "sha512-FviwfR+VyT3Datf13+ULjIMO5CSeajlayhhYQwpzgunswoaLIPutdbrnfUHEMyJCwvqQFaVtTmn9+Y8WCt6n1w==",
+                            "dev": true,
+                            "requires": {
+                                "jest-mock": "^22.4.3",
+                                "jest-util": "^22.4.3",
+                                "jsdom": "^11.5.1"
+                            }
+                        },
+                        "jest-get-type": {
+                            "version": "22.4.3",
+                            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+                            "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
+                            "dev": true
+                        },
+                        "jest-message-util": {
+                            "version": "22.4.3",
+                            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.3.tgz",
+                            "integrity": "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
+                            "dev": true,
+                            "requires": {
+                                "@babel/code-frame": "^7.0.0-beta.35",
+                                "chalk": "^2.0.1",
+                                "micromatch": "^2.3.11",
+                                "slash": "^1.0.0",
+                                "stack-utils": "^1.0.1"
+                            }
+                        },
+                        "jest-regex-util": {
+                            "version": "22.4.3",
+                            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.4.3.tgz",
+                            "integrity": "sha512-LFg1gWr3QinIjb8j833bq7jtQopiwdAs67OGfkPrvy7uNUbVMfTXXcOKXJaeY5GgjobELkKvKENqq1xrUectWg==",
+                            "dev": true
+                        },
+                        "jest-util": {
+                            "version": "22.4.3",
+                            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.4.3.tgz",
+                            "integrity": "sha512-rfDfG8wyC5pDPNdcnAlZgwKnzHvZDu8Td2NJI/jAGKEGxJPYiE4F0ss/gSAkG4778Y23Hvbz+0GMrDJTeo7RjQ==",
+                            "dev": true,
+                            "requires": {
+                                "callsites": "^2.0.0",
+                                "chalk": "^2.0.1",
+                                "graceful-fs": "^4.1.11",
+                                "is-ci": "^1.0.10",
+                                "jest-message-util": "^22.4.3",
+                                "mkdirp": "^0.5.1",
+                                "source-map": "^0.6.0"
+                            }
+                        }
                     }
                 },
                 "kind-of": {
@@ -5023,6 +5666,32 @@
                         "regex-cache": "^0.4.2"
                     }
                 },
+                "pretty-format": {
+                    "version": "22.4.3",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
+                    "integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0",
+                        "ansi-styles": "^3.2.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "source-map-support": {
+                    "version": "0.5.9",
+                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
+                    "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+                    "dev": true,
+                    "requires": {
+                        "buffer-from": "^1.0.0",
+                        "source-map": "^0.6.0"
+                    }
+                },
                 "strip-ansi": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -5031,16 +5700,13 @@
                     "requires": {
                         "ansi-regex": "^3.0.0"
                     }
+                },
+                "strip-bom": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+                    "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+                    "dev": true
                 }
-            }
-        },
-        "jest-changed-files": {
-            "version": "22.0.6",
-            "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-22.0.6.tgz",
-            "integrity": "sha512-eRnDzJm8gm0UsSV6H0LvIi5wANWDXmzKNglAl6zFRUv1K9FXTsqInE4zFWUzerGZv7LIvAYaVVAzyMrttbpcKQ==",
-            "dev": true,
-            "requires": {
-                "throat": "^4.0.0"
             }
         },
         "jest-config": {
@@ -5074,54 +5740,15 @@
                 "pretty-format": "^22.0.6"
             }
         },
-        "jest-docblock": {
-            "version": "22.0.6",
-            "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.0.6.tgz",
-            "integrity": "sha512-evcMu0AdVy1jchCz9ngB+PHxQchvHckInpP0OSjwyIji6UEpRU1m9XULpeIWp2D3odnIbLM/egeLEmRbQNhvJA==",
-            "dev": true,
-            "requires": {
-                "detect-newline": "^2.1.0"
-            }
-        },
         "jest-environment-jsdom": {
-            "version": "22.0.6",
-            "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.0.6.tgz",
-            "integrity": "sha512-a0YrUxW49YDMoj+LOgPZMhyh/dGUv6th4TbDfX4O/DVjkUGLzc4c6a0bCxcUZSkDuocXbxBYW8TAPIt84/OF1w==",
+            "version": "22.4.3",
+            "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.3.tgz",
+            "integrity": "sha512-FviwfR+VyT3Datf13+ULjIMO5CSeajlayhhYQwpzgunswoaLIPutdbrnfUHEMyJCwvqQFaVtTmn9+Y8WCt6n1w==",
             "dev": true,
             "requires": {
-                "jest-mock": "^22.0.6",
-                "jest-util": "^22.0.6",
+                "jest-mock": "^22.4.3",
+                "jest-util": "^22.4.3",
                 "jsdom": "^11.5.1"
-            }
-        },
-        "jest-environment-node": {
-            "version": "22.0.6",
-            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.0.6.tgz",
-            "integrity": "sha512-taEm3EjDx6B1bQKwOwnctp6ddajJIwW2qfRLfEpYNcKxthO4Y2b79jTGJPGYkwpXgGZBN9cYmBuCU8saguEXQw==",
-            "dev": true,
-            "requires": {
-                "jest-mock": "^22.0.6",
-                "jest-util": "^22.0.6"
-            }
-        },
-        "jest-get-type": {
-            "version": "22.0.6",
-            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.0.6.tgz",
-            "integrity": "sha512-NGiuzfSXssBIN5PGAmKPWk29/eJlv5gVhD7un9Dcr9w+rJXAOGR/Ggx3HKJ7IArkIq0YCN4lFdbyHpB42NMUWw==",
-            "dev": true
-        },
-        "jest-haste-map": {
-            "version": "22.0.6",
-            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.0.6.tgz",
-            "integrity": "sha512-Y/9MKcpI6AMobdHDIHOvz/0OiXiZNV5Uy997EyzRFWDb8EZTP8WD7nEqVCgG/4ned/DmxRnoCaHIZA2vS0/Vtg==",
-            "dev": true,
-            "requires": {
-                "fb-watchman": "^2.0.0",
-                "graceful-fs": "^4.1.11",
-                "jest-docblock": "^22.0.6",
-                "jest-worker": "^22.0.6",
-                "micromatch": "^2.3.11",
-                "sane": "^2.0.0"
             },
             "dependencies": {
                 "arr-diff": {
@@ -5168,6 +5795,40 @@
                         "is-extglob": "^1.0.0"
                     }
                 },
+                "jest-message-util": {
+                    "version": "22.4.3",
+                    "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.3.tgz",
+                    "integrity": "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0-beta.35",
+                        "chalk": "^2.0.1",
+                        "micromatch": "^2.3.11",
+                        "slash": "^1.0.0",
+                        "stack-utils": "^1.0.1"
+                    }
+                },
+                "jest-mock": {
+                    "version": "22.4.3",
+                    "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-22.4.3.tgz",
+                    "integrity": "sha512-+4R6mH5M1G4NK16CKg9N1DtCaFmuxhcIqF4lQK/Q1CIotqMs/XBemfpDPeVZBFow6iyUNu6EBT9ugdNOTT5o5Q==",
+                    "dev": true
+                },
+                "jest-util": {
+                    "version": "22.4.3",
+                    "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.4.3.tgz",
+                    "integrity": "sha512-rfDfG8wyC5pDPNdcnAlZgwKnzHvZDu8Td2NJI/jAGKEGxJPYiE4F0ss/gSAkG4778Y23Hvbz+0GMrDJTeo7RjQ==",
+                    "dev": true,
+                    "requires": {
+                        "callsites": "^2.0.0",
+                        "chalk": "^2.0.1",
+                        "graceful-fs": "^4.1.11",
+                        "is-ci": "^1.0.10",
+                        "jest-message-util": "^22.4.3",
+                        "mkdirp": "^0.5.1",
+                        "source-map": "^0.6.0"
+                    }
+                },
                 "kind-of": {
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -5197,8 +5858,30 @@
                         "parse-glob": "^3.0.4",
                         "regex-cache": "^0.4.2"
                     }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
                 }
             }
+        },
+        "jest-environment-node": {
+            "version": "22.0.6",
+            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.0.6.tgz",
+            "integrity": "sha512-taEm3EjDx6B1bQKwOwnctp6ddajJIwW2qfRLfEpYNcKxthO4Y2b79jTGJPGYkwpXgGZBN9cYmBuCU8saguEXQw==",
+            "dev": true,
+            "requires": {
+                "jest-mock": "^22.0.6",
+                "jest-util": "^22.0.6"
+            }
+        },
+        "jest-get-type": {
+            "version": "22.0.6",
+            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.0.6.tgz",
+            "integrity": "sha512-NGiuzfSXssBIN5PGAmKPWk29/eJlv5gVhD7un9Dcr9w+rJXAOGR/Ggx3HKJ7IArkIq0YCN4lFdbyHpB42NMUWw==",
+            "dev": true
         },
         "jest-jasmine2": {
             "version": "22.0.6",
@@ -5234,15 +5917,6 @@
                         "source-map": "^0.6.0"
                     }
                 }
-            }
-        },
-        "jest-leak-detector": {
-            "version": "22.0.6",
-            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.0.6.tgz",
-            "integrity": "sha512-Ll8C0iH8Un+liiOnnp18WTVScvhSr6GUFrhFa4p46peFWg8rgh4MuJvG7A1Dwpa00ZHV5W5kzVViFaedDWxJMw==",
-            "dev": true,
-            "requires": {
-                "pretty-format": "^22.0.6"
             }
         },
         "jest-matcher-utils": {
@@ -5367,140 +6041,11 @@
                 "chalk": "^2.0.1"
             }
         },
-        "jest-resolve-dependencies": {
-            "version": "22.0.6",
-            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-22.0.6.tgz",
-            "integrity": "sha512-JVbG4cE6N/1jTjut9XqveGqUddrHVlD7fJpIh5tH41ML+GjjDk8WwmcoA2RykXYSbt0vdUrAOV/FXVIgHTgHfw==",
-            "dev": true,
-            "requires": {
-                "jest-regex-util": "^22.0.6"
-            }
-        },
-        "jest-runner": {
-            "version": "22.0.6",
-            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.0.6.tgz",
-            "integrity": "sha512-xFXmP6T6IDIZYyieBJNZeyQcowCcaFXmtUra+yJJYpWp/zijGRpf8BPExbUeUM6Es59yTFnyepZrWXwZ5l1fRQ==",
-            "dev": true,
-            "requires": {
-                "jest-config": "^22.0.6",
-                "jest-docblock": "^22.0.6",
-                "jest-haste-map": "^22.0.6",
-                "jest-jasmine2": "^22.0.6",
-                "jest-leak-detector": "^22.0.6",
-                "jest-message-util": "^22.0.6",
-                "jest-runtime": "^22.0.6",
-                "jest-util": "^22.0.6",
-                "jest-worker": "^22.0.6",
-                "throat": "^4.0.0"
-            }
-        },
-        "jest-runtime": {
-            "version": "22.0.6",
-            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.0.6.tgz",
-            "integrity": "sha512-DM6fQb+ivYWkMCxTEOCV746i0ZoeNz+ksmar7pulJ4OT2wUG2P8f1GsXbfzM+AtoYMDfo/jPXSVmuudcAnppaw==",
-            "dev": true,
-            "requires": {
-                "babel-core": "^6.0.0",
-                "babel-jest": "^22.0.6",
-                "babel-plugin-istanbul": "^4.1.5",
-                "chalk": "^2.0.1",
-                "convert-source-map": "^1.4.0",
-                "graceful-fs": "^4.1.11",
-                "jest-config": "^22.0.6",
-                "jest-haste-map": "^22.0.6",
-                "jest-regex-util": "^22.0.6",
-                "jest-resolve": "^22.0.6",
-                "jest-util": "^22.0.6",
-                "json-stable-stringify": "^1.0.1",
-                "micromatch": "^2.3.11",
-                "realpath-native": "^1.0.0",
-                "slash": "^1.0.0",
-                "strip-bom": "3.0.0",
-                "write-file-atomic": "^2.1.0",
-                "yargs": "^10.0.3"
-            },
-            "dependencies": {
-                "arr-diff": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-                    "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-                    "dev": true,
-                    "requires": {
-                        "arr-flatten": "^1.0.1"
-                    }
-                },
-                "array-unique": {
-                    "version": "0.2.1",
-                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-                    "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-                    "dev": true
-                },
-                "braces": {
-                    "version": "1.8.5",
-                    "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-                    "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-                    "dev": true,
-                    "requires": {
-                        "expand-range": "^1.8.1",
-                        "preserve": "^0.2.0",
-                        "repeat-element": "^1.1.2"
-                    }
-                },
-                "expand-brackets": {
-                    "version": "0.1.5",
-                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-                    "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-                    "dev": true,
-                    "requires": {
-                        "is-posix-bracket": "^0.1.0"
-                    }
-                },
-                "extglob": {
-                    "version": "0.3.2",
-                    "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-                    "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "^1.0.0"
-                    }
-                },
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
-                },
-                "micromatch": {
-                    "version": "2.3.11",
-                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-                    "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-                    "dev": true,
-                    "requires": {
-                        "arr-diff": "^2.0.0",
-                        "array-unique": "^0.2.1",
-                        "braces": "^1.8.2",
-                        "expand-brackets": "^0.1.4",
-                        "extglob": "^0.3.1",
-                        "filename-regex": "^2.0.0",
-                        "is-extglob": "^1.0.0",
-                        "is-glob": "^2.0.1",
-                        "kind-of": "^3.0.2",
-                        "normalize-path": "^2.0.1",
-                        "object.omit": "^2.0.0",
-                        "parse-glob": "^3.0.4",
-                        "regex-cache": "^0.4.2"
-                    }
-                },
-                "strip-bom": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-                    "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-                    "dev": true
-                }
-            }
+        "jest-serializer": {
+            "version": "22.4.3",
+            "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-22.4.3.tgz",
+            "integrity": "sha512-uPaUAppx4VUfJ0QDerpNdF43F68eqKWCzzhUlKNDsUPhjOon7ZehR4C809GCqh765FoMRtTVUVnGvIoskkYHiw==",
+            "dev": true
         },
         "jest-snapshot": {
             "version": "22.0.6",
@@ -5541,15 +6086,6 @@
                 "jest-get-type": "^22.0.6",
                 "leven": "^2.1.0",
                 "pretty-format": "^22.0.6"
-            }
-        },
-        "jest-worker": {
-            "version": "22.0.6",
-            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.0.6.tgz",
-            "integrity": "sha512-4GlBXpqO/RrmaNF9unPkwNbqlQqR0VtYX4QpYfSUzxBEuuRT0w7PyKj99k15KUC2gRNlNK/eN/bY81LAeW1NEg==",
-            "dev": true,
-            "requires": {
-                "merge-stream": "^1.0.1"
             }
         },
         "js-tokens": {
@@ -5696,15 +6232,6 @@
             "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
             "dev": true
         },
-        "lazy-cache": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-            "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-            "dev": true,
-            "requires": {
-                "set-getter": "^0.1.0"
-            }
-        },
         "lcid": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
@@ -5777,9 +6304,9 @@
             }
         },
         "lodash": {
-            "version": "4.17.4",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-            "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+            "version": "4.17.10",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+            "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
             "dev": true
         },
         "lodash.flattendeep": {
@@ -5875,6 +6402,12 @@
             "requires": {
                 "object-visit": "^1.0.0"
             }
+        },
+        "math-random": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+            "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
+            "dev": true
         },
         "md5.js": {
             "version": "1.3.4",
@@ -5977,24 +6510,24 @@
             "dev": true
         },
         "micromatch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.5.tgz",
-            "integrity": "sha512-ykttrLPQrz1PUJcXjwsTUjGoPJ64StIGNE2lGVD1c9CuguJ+L7/navsE8IcDNndOoCMvYV0qc/exfVbMHkUhvA==",
+            "version": "3.1.10",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+            "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
             "dev": true,
             "requires": {
                 "arr-diff": "^4.0.0",
                 "array-unique": "^0.3.2",
-                "braces": "^2.3.0",
-                "define-property": "^1.0.0",
-                "extend-shallow": "^2.0.1",
-                "extglob": "^2.0.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
                 "fragment-cache": "^0.2.1",
-                "kind-of": "^6.0.0",
-                "nanomatch": "^1.2.5",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
                 "object.pick": "^1.3.0",
                 "regex-not": "^1.0.0",
                 "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
+                "to-regex": "^3.0.2"
             }
         },
         "miller-rabin": {
@@ -6071,9 +6604,9 @@
             "dev": true
         },
         "mixin-deep": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.0.tgz",
-            "integrity": "sha512-dgaCvoh6i1nosAUBKb0l0pfJ78K8+S9fluyIR2YvAeUD/QuMahnFnF3xYty5eYXMjhGSsB0DsW6A0uAZyetoAg==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+            "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
             "dev": true,
             "requires": {
                 "for-in": "^1.0.2",
@@ -6099,6 +6632,12 @@
             "requires": {
                 "minimist": "0.0.8"
             }
+        },
+        "moo": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
+            "integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==",
+            "dev": true
         },
         "ms": {
             "version": "2.0.0",
@@ -6130,30 +6669,22 @@
             "optional": true
         },
         "nanomatch": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.7.tgz",
-            "integrity": "sha512-/5ldsnyurvEw7wNpxLFgjVvBLMta43niEYOy0CJ4ntcYSbx6bugRUTQeFb4BR/WanEL1o3aQgHuVLHQaB6tOqg==",
+            "version": "1.2.13",
+            "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+            "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
             "dev": true,
             "requires": {
                 "arr-diff": "^4.0.0",
                 "array-unique": "^0.3.2",
-                "define-property": "^1.0.0",
-                "extend-shallow": "^2.0.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
                 "fragment-cache": "^0.2.1",
-                "is-odd": "^1.0.0",
-                "kind-of": "^5.0.2",
+                "is-windows": "^1.0.2",
+                "kind-of": "^6.0.2",
                 "object.pick": "^1.3.0",
                 "regex-not": "^1.0.0",
                 "snapdragon": "^0.8.1",
                 "to-regex": "^3.0.1"
-            },
-            "dependencies": {
-                "kind-of": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-                    "dev": true
-                }
             }
         },
         "natural-compare": {
@@ -6172,11 +6703,12 @@
             }
         },
         "nearley": {
-            "version": "2.11.1",
-            "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.11.1.tgz",
-            "integrity": "sha512-1azpqq1JvHKZNPEixS1jNEXf4kDilhFtr8AIZIGjP8N0TcAcUhKgi354niI5pM4JoOsMQ+H6vzCYWQa95LQjcw==",
+            "version": "2.15.1",
+            "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.15.1.tgz",
+            "integrity": "sha512-8IUY/rUrKz2mIynUGh8k+tul1awMKEjeHHC5G3FHvvyAW6oq4mQfNp2c0BMea+sYZJvYcrrM6GmZVIle/GRXGw==",
             "dev": true,
             "requires": {
+                "moo": "^0.4.3",
                 "nomnom": "~1.6.2",
                 "railroad-diagrams": "^1.0.0",
                 "randexp": "0.4.6",
@@ -6269,18 +6801,6 @@
                 }
             }
         },
-        "node-notifier": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.1.2.tgz",
-            "integrity": "sha1-L6nhJgX6EACdRFSdb82KY93g5P8=",
-            "dev": true,
-            "requires": {
-                "growly": "^1.3.0",
-                "semver": "^5.3.0",
-                "shellwords": "^0.1.0",
-                "which": "^1.2.12"
-            }
-        },
         "nomnom": {
             "version": "1.6.2",
             "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.6.2.tgz",
@@ -6351,9 +6871,9 @@
             "dev": true
         },
         "oauth-sign": {
-            "version": "0.8.2",
-            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-            "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
             "dev": true
         },
         "object-assign": {
@@ -6381,43 +6901,6 @@
                         "is-descriptor": "^0.1.0"
                     }
                 },
-                "is-accessor-descriptor": {
-                    "version": "0.1.6",
-                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-                    "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    }
-                },
-                "is-data-descriptor": {
-                    "version": "0.1.4",
-                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-                    "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    }
-                },
-                "is-descriptor": {
-                    "version": "0.1.6",
-                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-                    "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-                    "dev": true,
-                    "requires": {
-                        "is-accessor-descriptor": "^0.1.6",
-                        "is-data-descriptor": "^0.1.4",
-                        "kind-of": "^5.0.0"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "5.1.0",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                            "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-                            "dev": true
-                        }
-                    }
-                },
                 "kind-of": {
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -6430,9 +6913,9 @@
             }
         },
         "object-inspect": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.5.0.tgz",
-            "integrity": "sha512-UmOFbHbwvv+XHj7BerrhVq+knjceBdkvU5AriwLMvhv2qi+e7DJzxfBeFpILEjVzCp+xA+W/pIf06RGPWlZNfw==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+            "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
             "dev": true
         },
         "object-is": {
@@ -6593,24 +7076,12 @@
             }
         },
         "original": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
-            "integrity": "sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs=",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
+            "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
             "dev": true,
             "requires": {
-                "url-parse": "1.0.x"
-            },
-            "dependencies": {
-                "url-parse": {
-                    "version": "1.0.5",
-                    "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
-                    "integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=",
-                    "dev": true,
-                    "requires": {
-                        "querystringify": "0.0.x",
-                        "requires-port": "1.0.x"
-                    }
-                }
+                "url-parse": "^1.4.3"
             }
         },
         "os-browserify": {
@@ -7002,6 +7473,12 @@
             "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
             "dev": true
         },
+        "psl": {
+            "version": "1.1.29",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
+            "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
+            "dev": true
+        },
         "public-encrypt": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
@@ -7040,9 +7517,9 @@
             "dev": true
         },
         "querystringify": {
-            "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
-            "integrity": "sha1-DPf4T5Rj/wrlHExLFC2VvjdyTZw=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz",
+            "integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw==",
             "dev": true
         },
         "raf": {
@@ -7068,27 +7545,6 @@
             "requires": {
                 "discontinuous-range": "1.0.0",
                 "ret": "~0.1.10"
-            }
-        },
-        "randomatic": {
-            "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-            "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
-            "dev": true,
-            "requires": {
-                "is-number": "^3.0.0",
-                "kind-of": "^4.0.0"
-            },
-            "dependencies": {
-                "kind-of": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-                    "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
-                }
             }
         },
         "randombytes": {
@@ -7181,6 +7637,12 @@
                 }
             }
         },
+        "react-is": {
+            "version": "16.4.2",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.4.2.tgz",
+            "integrity": "sha512-rI3cGFj/obHbBz156PvErrS5xc6f1eWyTwyV4mo0vF2lGgXgS+mm7EKD5buLJq6jNgIagQescGSVG2YzgXt8Yg==",
+            "dev": true
+        },
         "react-proxy": {
             "version": "3.0.0-alpha.1",
             "resolved": "https://registry.npmjs.org/react-proxy/-/react-proxy-3.0.0-alpha.1.tgz",
@@ -7203,14 +7665,15 @@
             }
         },
         "react-test-renderer": {
-            "version": "16.2.0",
-            "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.2.0.tgz",
-            "integrity": "sha512-Kd4gJFtpNziR9ElOE/C23LeflKLZPRpNQYWP3nQBY43SJ5a+xyEGSeMrm2zxNKXcnCbBS/q1UpD9gqd5Dv+rew==",
+            "version": "16.4.2",
+            "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.4.2.tgz",
+            "integrity": "sha512-vdTPnRMDbxfv4wL4lzN4EkVGXyYs7LE2uImOsqh1FKiP6L5o1oJl8nore5sFi9vxrP9PK3l4rgb/fZ4PVUaWSA==",
             "dev": true,
             "requires": {
                 "fbjs": "^0.8.16",
                 "object-assign": "^4.1.1",
-                "prop-types": "^15.6.0"
+                "prop-types": "^15.6.0",
+                "react-is": "^16.4.2"
             }
         },
         "read-pkg": {
@@ -7346,12 +7809,13 @@
             }
         },
         "regex-not": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.0.tgz",
-            "integrity": "sha1-Qvg+OXcWIt+CawKvF2Ul1qXxV/k=",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+            "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
             "dev": true,
             "requires": {
-                "extend-shallow": "^2.0.1"
+                "extend-shallow": "^3.0.2",
+                "safe-regex": "^1.1.0"
             }
         },
         "regexpu-core": {
@@ -7443,33 +7907,70 @@
             }
         },
         "request": {
-            "version": "2.83.0",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-            "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+            "version": "2.88.0",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+            "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
             "dev": true,
             "requires": {
                 "aws-sign2": "~0.7.0",
-                "aws4": "^1.6.0",
+                "aws4": "^1.8.0",
                 "caseless": "~0.12.0",
-                "combined-stream": "~1.0.5",
-                "extend": "~3.0.1",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
                 "forever-agent": "~0.6.1",
-                "form-data": "~2.3.1",
-                "har-validator": "~5.0.3",
-                "hawk": "~6.0.2",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.0",
                 "http-signature": "~1.2.0",
                 "is-typedarray": "~1.0.0",
                 "isstream": "~0.1.2",
                 "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.17",
-                "oauth-sign": "~0.8.2",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
                 "performance-now": "^2.1.0",
-                "qs": "~6.5.1",
-                "safe-buffer": "^5.1.1",
-                "stringstream": "~0.0.5",
-                "tough-cookie": "~2.3.3",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.4.3",
                 "tunnel-agent": "^0.6.0",
-                "uuid": "^3.1.0"
+                "uuid": "^3.3.2"
+            },
+            "dependencies": {
+                "mime-db": {
+                    "version": "1.35.0",
+                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
+                    "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==",
+                    "dev": true
+                },
+                "mime-types": {
+                    "version": "2.1.19",
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
+                    "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
+                    "dev": true,
+                    "requires": {
+                        "mime-db": "~1.35.0"
+                    }
+                },
+                "qs": {
+                    "version": "6.5.2",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+                    "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+                    "dev": true
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                    "dev": true
+                },
+                "tough-cookie": {
+                    "version": "2.4.3",
+                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+                    "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+                    "dev": true,
+                    "requires": {
+                        "psl": "^1.1.24",
+                        "punycode": "^1.4.1"
+                    }
+                }
             }
         },
         "request-promise-core": {
@@ -7585,6 +8086,21 @@
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
             "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+            "dev": true
+        },
+        "safe-regex": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+            "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+            "dev": true,
+            "requires": {
+                "ret": "~0.1.10"
+            }
+        },
+        "safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
             "dev": true
         },
         "sane": {
@@ -7709,15 +8225,6 @@
             "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
             "dev": true
         },
-        "set-getter": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
-            "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
-            "dev": true,
-            "requires": {
-                "to-object-path": "^0.3.0"
-            }
-        },
         "set-immediate-shim": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
@@ -7734,6 +8241,17 @@
                 "is-extendable": "^0.1.1",
                 "is-plain-object": "^2.0.3",
                 "split-string": "^3.0.1"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
             }
         },
         "setimmediate": {
@@ -7807,9 +8325,9 @@
             "dev": true
         },
         "snapdragon": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.1.tgz",
-            "integrity": "sha1-4StUh/re0+PeoKyR6UAL91tAE3A=",
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+            "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
             "dev": true,
             "requires": {
                 "base": "^0.11.1",
@@ -7819,7 +8337,7 @@
                 "map-cache": "^0.2.2",
                 "source-map": "^0.5.6",
                 "source-map-resolve": "^0.5.0",
-                "use": "^2.0.0"
+                "use": "^3.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -7831,62 +8349,14 @@
                         "is-descriptor": "^0.1.0"
                     }
                 },
-                "is-accessor-descriptor": {
-                    "version": "0.1.6",
-                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-                    "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "dev": true,
-                            "requires": {
-                                "is-buffer": "^1.1.5"
-                            }
-                        }
+                        "is-extendable": "^0.1.0"
                     }
-                },
-                "is-data-descriptor": {
-                    "version": "0.1.4",
-                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-                    "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "dev": true,
-                            "requires": {
-                                "is-buffer": "^1.1.5"
-                            }
-                        }
-                    }
-                },
-                "is-descriptor": {
-                    "version": "0.1.6",
-                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-                    "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-                    "dev": true,
-                    "requires": {
-                        "is-accessor-descriptor": "^0.1.6",
-                        "is-data-descriptor": "^0.1.4",
-                        "kind-of": "^5.0.0"
-                    }
-                },
-                "kind-of": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-                    "dev": true
                 }
             }
         },
@@ -7899,6 +8369,46 @@
                 "define-property": "^1.0.0",
                 "isobject": "^3.0.0",
                 "snapdragon-util": "^3.0.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^1.0.0"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                }
             }
         },
         "snapdragon-util": {
@@ -7919,15 +8429,6 @@
                         "is-buffer": "^1.1.5"
                     }
                 }
-            }
-        },
-        "sntp": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-            "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-            "dev": true,
-            "requires": {
-                "hoek": "4.x.x"
             }
         },
         "sockjs": {
@@ -7986,12 +8487,12 @@
             "dev": true
         },
         "source-map-resolve": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
-            "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+            "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
             "dev": true,
             "requires": {
-                "atob": "^2.0.0",
+                "atob": "^2.1.1",
                 "decode-uri-component": "^0.2.0",
                 "resolve-url": "^0.2.1",
                 "source-map-url": "^0.4.0",
@@ -8087,27 +8588,6 @@
             "dev": true,
             "requires": {
                 "extend-shallow": "^3.0.0"
-            },
-            "dependencies": {
-                "extend-shallow": {
-                    "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-                    "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-                    "dev": true,
-                    "requires": {
-                        "assign-symbols": "^1.0.0",
-                        "is-extendable": "^1.0.1"
-                    }
-                },
-                "is-extendable": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-                    "dev": true,
-                    "requires": {
-                        "is-plain-object": "^2.0.4"
-                    }
-                }
             }
         },
         "sprintf-js": {
@@ -8117,9 +8597,9 @@
             "dev": true
         },
         "sshpk": {
-            "version": "1.13.1",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-            "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+            "version": "1.14.2",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+            "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
             "dev": true,
             "requires": {
                 "asn1": "~0.2.3",
@@ -8129,6 +8609,7 @@
                 "ecc-jsbn": "~0.1.1",
                 "getpass": "^0.1.1",
                 "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
                 "tweetnacl": "~0.14.0"
             }
         },
@@ -8162,63 +8643,6 @@
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
-                },
-                "is-accessor-descriptor": {
-                    "version": "0.1.6",
-                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-                    "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "dev": true,
-                            "requires": {
-                                "is-buffer": "^1.1.5"
-                            }
-                        }
-                    }
-                },
-                "is-data-descriptor": {
-                    "version": "0.1.4",
-                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-                    "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "dev": true,
-                            "requires": {
-                                "is-buffer": "^1.1.5"
-                            }
-                        }
-                    }
-                },
-                "is-descriptor": {
-                    "version": "0.1.6",
-                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-                    "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-                    "dev": true,
-                    "requires": {
-                        "is-accessor-descriptor": "^0.1.6",
-                        "is-data-descriptor": "^0.1.4",
-                        "kind-of": "^5.0.0"
-                    }
-                },
-                "kind-of": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-                    "dev": true
                 }
             }
         },
@@ -8319,12 +8743,6 @@
             "requires": {
                 "safe-buffer": "~5.1.0"
             }
-        },
-        "stringstream": {
-            "version": "0.0.5",
-            "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-            "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-            "dev": true
         },
         "strip-ansi": {
             "version": "3.0.1",
@@ -8597,82 +9015,15 @@
             }
         },
         "to-regex": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.1.tgz",
-            "integrity": "sha1-FTWL7kosg712N3uh3ASdDxiDeq4=",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+            "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
             "dev": true,
             "requires": {
-                "define-property": "^0.2.5",
-                "extend-shallow": "^2.0.1",
-                "regex-not": "^1.0.0"
-            },
-            "dependencies": {
-                "define-property": {
-                    "version": "0.2.5",
-                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                    "dev": true,
-                    "requires": {
-                        "is-descriptor": "^0.1.0"
-                    }
-                },
-                "is-accessor-descriptor": {
-                    "version": "0.1.6",
-                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-                    "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "dev": true,
-                            "requires": {
-                                "is-buffer": "^1.1.5"
-                            }
-                        }
-                    }
-                },
-                "is-data-descriptor": {
-                    "version": "0.1.4",
-                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-                    "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "dev": true,
-                            "requires": {
-                                "is-buffer": "^1.1.5"
-                            }
-                        }
-                    }
-                },
-                "is-descriptor": {
-                    "version": "0.1.6",
-                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-                    "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-                    "dev": true,
-                    "requires": {
-                        "is-accessor-descriptor": "^0.1.6",
-                        "is-data-descriptor": "^0.1.4",
-                        "kind-of": "^5.0.0"
-                    }
-                },
-                "kind-of": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-                    "dev": true
-                }
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "regex-not": "^1.0.2",
+                "safe-regex": "^1.1.0"
             }
         },
         "to-regex-range": {
@@ -9034,9 +9385,9 @@
             }
         },
         "typescript": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
-            "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
+            "version": "2.9.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
+            "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
             "dev": true
         },
         "ua-parser-js": {
@@ -9123,6 +9474,15 @@
                 "set-value": "^0.4.3"
             },
             "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                },
                 "set-value": {
                     "version": "0.4.3",
                     "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
@@ -9231,101 +9591,20 @@
             }
         },
         "url-parse": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.2.0.tgz",
-            "integrity": "sha512-DT1XbYAfmQP65M/mE6OALxmXzZ/z1+e5zk2TcSKe/KiYbNGZxgtttzC0mR/sjopbpOXcbniq7eIKmocJnUWlEw==",
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
+            "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
             "dev": true,
             "requires": {
-                "querystringify": "~1.0.0",
-                "requires-port": "~1.0.0"
-            },
-            "dependencies": {
-                "querystringify": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz",
-                    "integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs=",
-                    "dev": true
-                }
+                "querystringify": "^2.0.0",
+                "requires-port": "^1.0.0"
             }
         },
         "use": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/use/-/use-2.0.2.tgz",
-            "integrity": "sha1-riig1y+TvyJCKhii43mZMRLeyOg=",
-            "dev": true,
-            "requires": {
-                "define-property": "^0.2.5",
-                "isobject": "^3.0.0",
-                "lazy-cache": "^2.0.2"
-            },
-            "dependencies": {
-                "define-property": {
-                    "version": "0.2.5",
-                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                    "dev": true,
-                    "requires": {
-                        "is-descriptor": "^0.1.0"
-                    }
-                },
-                "is-accessor-descriptor": {
-                    "version": "0.1.6",
-                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-                    "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "dev": true,
-                            "requires": {
-                                "is-buffer": "^1.1.5"
-                            }
-                        }
-                    }
-                },
-                "is-data-descriptor": {
-                    "version": "0.1.4",
-                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-                    "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "dev": true,
-                            "requires": {
-                                "is-buffer": "^1.1.5"
-                            }
-                        }
-                    }
-                },
-                "is-descriptor": {
-                    "version": "0.1.6",
-                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-                    "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-                    "dev": true,
-                    "requires": {
-                        "is-accessor-descriptor": "^0.1.6",
-                        "is-data-descriptor": "^0.1.4",
-                        "kind-of": "^5.0.0"
-                    }
-                },
-                "kind-of": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-                    "dev": true
-                }
-            }
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+            "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+            "dev": true
         },
         "user-home": {
             "version": "1.1.1",
@@ -9379,9 +9658,9 @@
             "dev": true
         },
         "uuid": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-            "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
             "dev": true
         },
         "v8flags": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "siema-react",
-    "version": "0.0.9",
+    "version": "0.1.0",
     "description": "React binding to lightweight slider library named Siema",
     "main": "dist/siema-react.js",
     "types": "./tsc/src/lib/siema-react.d.ts",
@@ -15,7 +15,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/aczekajski/siema-react.git"
+        "url": "git+https://github.com/x-kom/siema-react.git"
     },
     "keywords": [
         "react",
@@ -26,9 +26,9 @@
     "author": "arkadiusz.czekajski@x-kom.pl",
     "license": "MIT",
     "bugs": {
-        "url": "https://github.com/aczekajski/siema-react/issues"
+        "url": "https://github.com/x-kom/siema-react/issues"
     },
-    "homepage": "https://github.com/aczekajski/siema-react#readme",
+    "homepage": "https://github.com/x-kom/siema-react#readme",
     "dependencies": {
         "react": "^16.2.0",
         "react-dom": "^16.2.0",
@@ -40,11 +40,11 @@
         "@types/react": "^16.0.34",
         "@types/react-dom": "^16.0.3",
         "@types/webpack-env": "^1.13.3",
-        "enzyme": "^3.3.0",
-        "enzyme-adapter-react-16": "^1.1.1",
         "awesome-typescript-loader": "3.4.1",
         "babel-cli": "^6.26.0",
         "babel-preset-es2015": "^6.24.1",
+        "enzyme": "^3.4.4",
+        "enzyme-adapter-react-16": "^1.2.0",
         "html-webpack-plugin": "2.30.1",
         "jest": "22.0.4",
         "react-hot-loader": "3.0.0-beta.7",
@@ -57,7 +57,7 @@
         "tslint-immutable": "4.5.0",
         "tslint-microsoft-contrib": "5.0.1",
         "tslint-react": "3.2.0",
-        "typescript": "^2.6.2",
+        "typescript": "^2.9.0",
         "url-loader": "0.6.2",
         "webpack": "3.10.0",
         "webpack-dev-server": "2.9.7",

--- a/src/demo/index.tsx
+++ b/src/demo/index.tsx
@@ -4,7 +4,7 @@ import Siema from '../lib/siema-react';
 import styled from 'styled-components';
 import { WithBlur, SliderWithActiveSlide } from './components';
 
-const BigSlider = styled(Siema) `
+const BigSlider = styled(Siema)`
     width: 400px;
 
     img {
@@ -12,7 +12,7 @@ const BigSlider = styled(Siema) `
     }
 `;
 
-const SmallSlider = styled(Siema) `
+const SmallSlider = styled(Siema)`
     width: 100px;
     margin: 0 150px;
 
@@ -24,7 +24,7 @@ const SmallSlider = styled(Siema) `
     }
 `;
 
-const TripleSlider = styled(Siema) `
+const TripleSlider = styled(Siema)`
     width: 300px;
 
     img {
@@ -58,7 +58,7 @@ const SmallSliderWrapper = styled.div`
     }
 `;
 
-const FullWidthSlider = styled(Siema) `
+const FullWidthSlider = styled(Siema)`
     width: 100%;
 `;
 

--- a/src/lib/siema-react.tsx
+++ b/src/lib/siema-react.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import SiemaBase, { SiemaOptions } from 'siema';
 
-export type Diff<T extends string, U extends string> = ({[P in T]: P } & {[P in U]: never } & { [x: string]: never })[T];
+export type Diff<T, U> = T extends U ? never : T;
 export type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
 export type Overwrite<T, U> = Pick<T, Diff<keyof T, keyof U>> & U;
 

--- a/src/tests/siema-react.spec.tsx
+++ b/src/tests/siema-react.spec.tsx
@@ -33,7 +33,8 @@ describe('Siema react', () => {
 
     it('should properly mount component with all given children', () => {
         expect(component).toHaveLength(1);
-        expect(component.find(ExampleChildren)).toHaveLength(images.length);
+        expect(component.children().filterWhere(n => n.type() === ExampleChildren)).toHaveLength(images.length)
+        expect(component.find('SiemaWrapper').find(ExampleChildren)).toHaveLength(images.length);
     });
 
     it('should have default Siema props', () => {

--- a/src/tests/siema-react.spec.tsx
+++ b/src/tests/siema-react.spec.tsx
@@ -33,7 +33,7 @@ describe('Siema react', () => {
 
     it('should properly mount component with all given children', () => {
         expect(component).toHaveLength(1);
-        expect(component.children().filterWhere(n => n.type() === ExampleChildren)).toHaveLength(images.length)
+        expect(component.children().filterWhere((n) => n.type() === ExampleChildren)).toHaveLength(images.length)
         expect(component.find('SiemaWrapper').find(ExampleChildren)).toHaveLength(images.length);
     });
 


### PR DESCRIPTION
This one bumps TS to version ^2.9
changes the Diff type
fixes the urls in package.json and license file
and fixes the tests